### PR TITLE
libblkid: ignore private Stratis devices

### DIFF
--- a/disk-utils/fdisk-list.c
+++ b/disk-utils/fdisk-list.c
@@ -334,7 +334,7 @@ char *next_proc_partition(FILE **f)
 		if (devno <= 0)
 			continue;
 
-		if (sysfs_devno_is_lvm_private(devno, NULL) ||
+		if (sysfs_devno_is_dm_private(devno, NULL) ||
 		    sysfs_devno_is_wholedisk(devno) <= 0)
 			continue;
 

--- a/include/sysfs.h
+++ b/include/sysfs.h
@@ -81,7 +81,7 @@ extern int sysfs_is_partition_dirent(DIR *dir, struct dirent *d,
 extern int sysfs_devno_to_wholedisk(dev_t dev, char *diskname,
             size_t len, dev_t *diskdevno);
 
-extern int sysfs_devno_is_lvm_private(dev_t devno, char **uuid);
+extern int sysfs_devno_is_dm_private(dev_t devno, char **uuid);
 extern int sysfs_devno_is_wholedisk(dev_t devno);
 
 extern int sysfs_scsi_get_hctl(struct sysfs_cxt *cxt, int *h,

--- a/libblkid/src/probe.c
+++ b/libblkid/src/probe.c
@@ -923,8 +923,8 @@ int blkid_probe_set_device(blkid_probe pr, int fd,
 		pr->flags |= BLKID_FL_TINY_DEV;
 
 	if (S_ISBLK(sb.st_mode) &&
-	    sysfs_devno_is_lvm_private(sb.st_rdev, &dm_uuid)) {
-		DBG(LOWPROBE, ul_debug("ignore private LVM device"));
+	    sysfs_devno_is_dm_private(sb.st_rdev, &dm_uuid)) {
+		DBG(LOWPROBE, ul_debug("ignore private device mapper device"));
 		pr->flags |= BLKID_FL_NOSCAN_DEV;
 	}
 

--- a/libblkid/src/verify.c
+++ b/libblkid/src/verify.c
@@ -114,7 +114,7 @@ blkid_dev blkid_verify(blkid_cache cache, blkid_dev dev)
 		   (unsigned long)diff));
 #endif
 
-	if (sysfs_devno_is_lvm_private(st.st_rdev, NULL)) {
+	if (sysfs_devno_is_dm_private(st.st_rdev, NULL)) {
 		blkid_free_dev(dev);
 		return NULL;
 	}


### PR DESCRIPTION
Ref. 20e1c3dc03399d6988ef35dedc1364cfc12e9263

Signed-off-by: Tony Asleson <tasleson@redhat.com>

Looking much better

### Previous
``` 
[root@strat util-linux]# blkid
/dev/mapper/stratis-1-054df9cec7d14b91b050d6ea32776f74-thin-fs-d8dfc2d754724deeba3a89484377dc25: UUID="d8dfc2d7-5472-4dee-ba3a-89484377dc25" TYPE="xfs"
/dev/sda1: UUID="cc97b2a8-1f9e-490b-883b-e53da92116b3" TYPE="ext4" PARTUUID="9c220e1f-01"
/dev/sda2: UUID="70f45ac9-1be5-4a75-ab21-f165cd96f759" TYPE="swap" PARTUUID="9c220e1f-02"
/dev/sda3: UUID="565c8028-1774-42c5-b275-c1673f55b8b4" TYPE="ext4" PARTUUID="9c220e1f-03"
/dev/mapper/stratis-1-054df9cec7d14b91b050d6ea32776f74-flex-thindata: UUID="d8dfc2d7-5472-4dee-ba3a-89484377dc25" TYPE="xfs"
/dev/mapper/stratis-1-054df9cec7d14b91b050d6ea32776f74-thinpool-pool: UUID="d8dfc2d7-5472-4dee-ba3a-89484377dc25" TYPE="xfs"
/dev/mapper/stratis-1-054df9cec7d14b91b050d6ea32776f74-flex-mdv: UUID="054df9ce-c7d1-4b91-b050-d6ea32776f74" TYPE="xfs"
```

### With this change
```
[root@strat util-linux]# ./blkid
/dev/mapper/stratis-1-054df9cec7d14b91b050d6ea32776f74-thin-fs-d8dfc2d754724deeba3a89484377dc25: UUID="d8dfc2d7-5472-4dee-ba3a-89484377dc25" TYPE="xfs"
/dev/sda1: UUID="cc97b2a8-1f9e-490b-883b-e53da92116b3" TYPE="ext4" PARTUUID="9c220e1f-01"
/dev/sda2: UUID="70f45ac9-1be5-4a75-ab21-f165cd96f759" TYPE="swap" PARTUUID="9c220e1f-02"
/dev/sda3: UUID="565c8028-1774-42c5-b275-c1673f55b8b4" TYPE="ext4" PARTUUID="9c220e1f-03"
/dev/sdb: UUID="dad3f86413db4a1392aa0a2a74bda8d2" POOL_UUID="054df9cec7d14b91b050d6ea32776f74" BLOCKDEV_SECTORS="75497472" BLOCKDEV_INITTIME="1518802501" TYPE="stratis"
```